### PR TITLE
Non-standard headers loading

### DIFF
--- a/segfast/__init__.py
+++ b/segfast/__init__.py
@@ -2,5 +2,6 @@
 from .segyio_loader import SegyioLoader, SafeSegyioLoader
 from .memmap_loader import MemmapLoader
 from .loader import Loader, File, open #pylint: disable=redefined-builtin
+from .trace_header_spec import TraceHeaderSpec
 
 __version__ = '1.0.1'

--- a/segfast/loader.py
+++ b/segfast/loader.py
@@ -5,7 +5,7 @@ from .memmap_loader import MemmapLoader
 
 
 def Loader(path, engine='memmap', endian='big', strict=False, ignore_geometry=True):
-    """ SEG-Y loader. """
+    """ Selector class for loading SEG-Y with either segyio-based loader or memmap-based one. """
     loader_class = _select_loader_class(engine)
     return loader_class(path=path, endian=endian, strict=strict, ignore_geometry=ignore_geometry)
 open = File = Loader

--- a/segfast/loader.py
+++ b/segfast/loader.py
@@ -5,7 +5,7 @@ from .memmap_loader import MemmapLoader
 
 
 def Loader(path, engine='memmap', endian='big', strict=False, ignore_geometry=True):
-    """ !!. """
+    """ Loader. """
     loader_class = _select_loader_class(engine)
     return loader_class(path=path, endian=endian, strict=strict, ignore_geometry=ignore_geometry)
 open = File = Loader

--- a/segfast/loader.py
+++ b/segfast/loader.py
@@ -5,7 +5,7 @@ from .memmap_loader import MemmapLoader
 
 
 def Loader(path, engine='memmap', endian='big', strict=False, ignore_geometry=True):
-    """ Loader. """
+    """ SEG-Y loader. """
     loader_class = _select_loader_class(engine)
     return loader_class(path=path, endian=endian, strict=strict, ignore_geometry=ignore_geometry)
 open = File = Loader

--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -209,7 +209,8 @@ class MemmapLoader(SegyioLoader):
         headers = sorted(headers, key=lambda x: x.start_byte)
 
         unused_counter = 0
-        if headers[0].start_byte != 0:
+        dtype_list = []
+        if headers[0].start_byte != 1:
             dtype_list = [(f'unused_{unused_counter}', np.void, headers[0].start_byte - 1)]
             unused_counter += 1
 

--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -141,7 +141,7 @@ class MemmapLoader(SegyioLoader):
         mmap_trace_dtype = np.dtype([*mmap_trace_headers_dtype,
                                      ('data', self.mmap_trace_data_dtype, self.mmap_trace_data_size)])
 
-        dst_headers_dtype = [item for item in mmap_trace_headers_dtype if not item[0].startswith('unused')]
+        dst_headers_dtype = [(header.name, mmap_trace_dtype.fields[header.name][0]) for header in headers]
         dst_headers_dtype = np.dtype(dst_headers_dtype).newbyteorder("=")
 
         # Split the whole file into chunks no larger than `chunk_size`

--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -138,12 +138,8 @@ class MemmapLoader(SegyioLoader):
         mmap_trace_dtype = np.dtype([*mmap_trace_headers_dtype,
                                      ('data', self.mmap_trace_data_dtype, self.mmap_trace_data_size)])
 
-        print(mmap_trace_dtype)
-        dst_headers_dtype = []
-        for item in mmap_trace_headers_dtype:
-            if item[0].startswith('unused'):
-                continue
-            dst_headers_dtype.append((item[0], item[1][1:]))
+        dst_headers_dtype = [item for item in mmap_trace_headers_dtype if not item[0].startswith('unused')]
+        dst_headers_dtype = np.dtype(dst_headers_dtype).newbyteorder("=")
 
         # Split the whole file into chunks no larger than `chunk_size`
         n_chunks, last_chunk_size = divmod(self.n_traces, chunk_size)
@@ -173,8 +169,8 @@ class MemmapLoader(SegyioLoader):
                 for start, chunk_size_ in zip(chunk_starts, chunk_sizes):
                     future = executor.submit(read_chunk, path=self.path,
                                              shape=self.n_traces, offset=self.file_traces_offset,
-                                             dtype=mmap_trace_dtype, headers=headers,
-                                             start=start, chunk_size=chunk_size_)
+                                             mmap_dtype=mmap_trace_dtype, buffer_dtype=dst_headers_dtype,
+                                             headers=headers, start=start, chunk_size=chunk_size_)
                     future.add_done_callback(partial(callback, start=start))
 
         # Convert to pd.DataFrame, optionally add TSF and sort
@@ -402,19 +398,17 @@ class MemmapLoader(SegyioLoader):
         return path
 
 
-def read_chunk(path, shape, offset, dtype, headers, start, chunk_size):
+def read_chunk(path, shape, offset, mmap_dtype, buffer_dtype, headers, start, chunk_size):
     """ Read headers from one chunk.
     We create memory mapping anew in each worker, as it is easier and creates no significant overhead.
     """
     # mmap is created over the entire file as
     # creating data over the requested chunk only does not speed up anything
-    mmap = np.memmap(filename=path, mode='r', shape=shape, offset=offset, dtype=dtype)
-    return np.array(mmap[[header.name for header in headers]][start : start + chunk_size])
+    mmap = np.memmap(filename=path, mode='r', shape=shape, offset=offset, dtype=mmap_dtype)
 
-    # buffer = np.empty((chunk_size, len(headers)), dtype=np.int32)
-    # for i, header in enumerate(headers):
-    #     buffer[:, i] = mmap[header.name][start : start + chunk_size]
-    # return buffer
+    buffer = np.empty(chunk_size, dtype=buffer_dtype)
+    buffer[:] = mmap[[header.name for header in headers]][start : start + chunk_size]
+    return buffer
 
 
 def convert_chunk(src_path, dst_path, shape, offset, src_dtype, dst_dtype, endian, transform, start, chunk_size):

--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -174,7 +174,7 @@ class MemmapLoader(SegyioLoader):
                     future.add_done_callback(partial(callback, start=start))
 
         # Convert to pd.DataFrame, optionally add TSF and sort
-        dataframe = pd.DataFrame(buffer, columns=[header.name for header in headers], copy=False)
+        dataframe = pd.DataFrame(buffer, copy=False)
         dataframe = self.postprocess_headers_dataframe(dataframe, headers=headers,
                                                        reconstruct_tsf=reconstruct_tsf, sort_columns=sort_columns)
         return dataframe

--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -208,7 +208,7 @@ class MemmapLoader(SegyioLoader):
             unused_counter += 1
 
         for i, header in enumerate(headers):
-            header_dtype = (header.name, endian_symbol + header.dtype)
+            header_dtype = (header.name, str(header.dtype))
             dtype_list.append(header_dtype)
 
             next_byte_position = headers[i+1].start_byte if i+1 < len(headers) else TraceHeaderSpec.TRACE_HEADER_SIZE + 1

--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -77,7 +77,7 @@ class MemmapLoader(SegyioLoader):
 
         # Dtype of each trace
         # TODO: maybe, use `np.uint8` as dtype instead of `np.void` for headers as it has nicer repr
-        self.mmap_trace_dtype = np.dtype([('headers', np.void, self.TRACE_HEADER_SIZE),
+        self.mmap_trace_dtype = np.dtype([('headers', np.void, TraceHeaderSpec.TRACE_HEADER_SIZE),
                                           ('data', self.mmap_trace_data_dtype, self.mmap_trace_data_size)])
         self.data_mmap = self._construct_data_mmap()
 
@@ -346,7 +346,8 @@ class MemmapLoader(SegyioLoader):
         # Compute target dtype, itemsize, size of the dst file
         dst_dtype = self.endian_symbol + self.SEGY_FORMAT_TO_TRACE_DATA_DTYPE[format]
         dst_itemsize = np.dtype(dst_dtype).itemsize
-        dst_size = self.file_traces_offset + self.n_traces * (self.TRACE_HEADER_SIZE + self.n_samples * dst_itemsize)
+        dst_size = self.file_traces_offset + \
+                   self.n_traces * (TraceHeaderSpec.TRACE_HEADER_SIZE + self.n_samples * dst_itemsize)
 
         # Exceptions
         traces = self.load_traces([0])
@@ -369,7 +370,7 @@ class MemmapLoader(SegyioLoader):
         dst_mmap[3225-1:3225-1+2] = np.array([format], dtype=self.endian_symbol + 'u2').view('u1')
 
         # Prepare dst dtype
-        dst_trace_dtype = np.dtype([('headers', np.void, self.TRACE_HEADER_SIZE),
+        dst_trace_dtype = np.dtype([('headers', np.void, TraceHeaderSpec.TRACE_HEADER_SIZE),
                                     ('data', dst_dtype, self.n_samples)])
 
         # Split the whole file into chunks no larger than `chunk_size`

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -6,7 +6,8 @@ import numpy as np
 import pandas as pd
 
 import segyio
-from .utils import Notifier, TraceHeaderSpec
+from .trace_header_spec import TraceHeaderSpec
+from .utils import Notifier
 
 
 
@@ -164,7 +165,7 @@ class SegyioLoader:
             else:
                 if isinstance(header, int):
                     header = (None, header)
-                if not isinstance(header, (list, tuple, dict)):
+                if isinstance(header, str):
                     header = (header,)
                 if isinstance(header, dict):
                     init_kwargs = header

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -157,7 +157,7 @@ class SegyioLoader:
         headers_ = []
         for header in headers:
             if isinstance(header, TraceHeaderSpec):
-                headers_.append(header.set_byteorder(byteorder))
+                headers_.append(header.set_default_byteorder(byteorder))
             else:
                 if isinstance(header, str):
                     init_kwargs = {'name': header}

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -145,13 +145,16 @@ class SegyioLoader:
 
     def _make_headers_specs(self, headers):
         """ Make instances of TraceHeader. """
+        byteorder = self.ENDIANNESS_TO_SYMBOL[self.endian]
+
         if headers == 'all':
-            return [TraceHeaderSpec(start_byte) for start_byte in TraceHeaderSpec.STANDARD_BYTE_TO_HEADER]
+            return [TraceHeaderSpec(start_byte, byteorder=byteorder)
+                    for start_byte in TraceHeaderSpec.STANDARD_BYTE_TO_HEADER]
 
         headers_ = []
         for header in headers:
             if isinstance(header, TraceHeaderSpec):
-                headers_.append(header)
+                headers_.append(header.set_byteorder(byteorder))
             else:
                 if isinstance(header, str):
                     init_kwargs = {'name': header}
@@ -162,6 +165,7 @@ class SegyioLoader:
                     init_kwargs = {arg_name: header[0], 'dtype': header[1]}
                 elif isinstance(header, dict):
                     init_kwargs = header
+                init_kwargs = {'byteorder': byteorder, **init_kwargs}
                 headers_.append(TraceHeaderSpec(**init_kwargs))
         return headers_
 

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -174,8 +174,7 @@ class SegyioLoader:
 
     def load_header(self, header):
         """ Read one header from the file. """
-        if isinstance(header, (int, str)):
-            header = TraceHeaderSpec(header)
+        header = self._make_headers_specs([header])[0]
         return self.file_handler.attributes(header.start_byte)[:]
 
     def make_tsf_header(self):

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -20,8 +20,6 @@ class SegyioLoader:
     This gives up to 50% speed-up over public API for the scenario of loading sequence of traces,
     and up to 15% over public API in case of loading full lines (inlines or crosslines).
     """
-    TRACE_HEADER_SIZE = 240
-
     SEGY_FORMAT_TO_TRACE_DATA_DTYPE = {
         1:  "u1",  # IBM 4-byte float: has to be manually transformed to an IEEE float32
         2:  "i4",

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -4,6 +4,7 @@ from copy import copy
 import numpy as np
 import pandas as pd
 
+import warnings
 import segyio
 from .utils import Notifier, TraceHeaderSpec
 
@@ -123,6 +124,8 @@ class SegyioLoader:
         """
         _ = kwargs
         headers = self._make_headers_specs(headers)
+        if not all([header.is_standard_except_name for header in headers]):
+            warnings.warn("All nonstandard trace headers byte positions and dtypes will be ignored.")
 
         if reconstruct_tsf:
             headers = [header for header in headers if header.name != 'TRACE_SEQUENCE_FILE']

--- a/segfast/trace_header_spec.py
+++ b/segfast/trace_header_spec.py
@@ -111,7 +111,9 @@ class TraceHeaderSpec:
         return f"{class_name}(name='{self.name}', start_byte={self.start_byte}, dtype='{self._spec_params[2]}')"
 
     def to_tuple(self):
+        """ Make a tuple of input params of the header. """
         return self._spec_params
 
     def to_dict(self):
+        """ Make a dict of input params of the header. """
         return dict(zip(['name', 'start_byte', 'dtype'], self._spec_params))

--- a/segfast/trace_header_spec.py
+++ b/segfast/trace_header_spec.py
@@ -1,0 +1,117 @@
+""" Class to specify headers to load. """
+
+import numpy as np
+import segyio
+
+class TraceHeaderSpec:
+    """ Trace header class to store its name and byte position. By default, byte position is defined by name
+    accordingly to SEG-Y specification.
+
+    Parameters
+    ----------
+    name : str
+        Name of the header.
+    start_byte : int, optional
+        Byte position of the header, by default None. If None, default byte position from the spec will be used.
+    dtype : int, str or dtype, optional
+        dtype for header (e.g. 'i2', '>f4', `np.float32`) or its length in bytes (then is interpreted as integer type).
+    byteorder : '>' or '<', optional
+        Endianness to use, if it's not defined by dtype. If None and dtype doesn't specify, architecture default
+        will be used.
+    """
+    TRACE_HEADER_SIZE = 240
+
+    STANDARD_HEADER_TO_BYTE = segyio.tracefield.keys
+    STANDARD_BYTE_TO_HEADER = {v: k for k, v in STANDARD_HEADER_TO_BYTE.items()}
+
+    START_BYTES = sorted(STANDARD_HEADER_TO_BYTE.values())
+    STANDARD_BYTE_TO_LEN = {start: end - start
+                            for start, end in zip(START_BYTES, START_BYTES[1:] + [TRACE_HEADER_SIZE + 1])}
+
+    def __init__(self, name=None, start_byte=None, dtype=None, byteorder=None):
+        self.name = name or self.STANDARD_BYTE_TO_HEADER[start_byte]
+        self.start_byte = start_byte or self.STANDARD_HEADER_TO_BYTE[name]
+
+        dtype = dtype or self.STANDARD_BYTE_TO_LEN[self.start_byte]
+        if isinstance(dtype, int):
+            dtype = 'i' + str(dtype)
+
+        self.dtype = np.dtype(dtype)
+        self.default_byteorder = byteorder
+        self.has_explicit_byteorder = isinstance(dtype, str) and dtype[0] in {'>', '<'}
+        if not self.has_explicit_byteorder and byteorder is not None:
+            self.dtype = self.dtype.newbyteorder(byteorder)
+
+        if self.start_byte + self.byte_len > self.TRACE_HEADER_SIZE + 1:
+            raise ValueError(f'{self.name} header position is out of bounds')
+
+    @property
+    def byte_len(self):
+        """ The number of bytes for a header. """
+        return self.dtype.itemsize
+
+    @property
+    def is_standard(self):
+        """ Whether the header matches the specification. """
+        return self.name in self.STANDARD_BYTE_TO_HEADER and self.has_standard_location
+
+    @property
+    def has_standard_location(self):
+        """ Whether the header matches the specification, except maybe the name. """
+        return self.start_byte in self.STANDARD_BYTE_TO_HEADER and \
+               self.byte_len == self.STANDARD_BYTE_TO_LEN[self.start_byte] and \
+               np.issubdtype(self.dtype, np.integer)
+
+    @property
+    def standard_name(self):
+        """ The name from specification for header (if 'has_standard_location' is True). """
+        if not self.has_standard_location:
+            raise ValueError("The header has non-standard start byte or dtype")
+        return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
+
+    @property
+    def has_default_byteorder(self):
+        """ Whether default byteorder is defined. """
+        return self.default_byteorder is not None
+
+    @property
+    def has_byteorder(self):
+        """ Whether byteorder is defined. """
+        return self.has_explicit_byteorder or self.has_default_byteorder
+
+    @property
+    def byteorder(self):
+        """ Header byteorder (if defined). """
+        if not self.has_byteorder:
+            return None
+        return self.dtype.str[0]
+
+    @property
+    def _spec_params(self):
+        dtype_str = self.dtype.str
+        if not self.has_byteorder:
+            dtype_str = dtype_str[1:]
+        return self.name, self.start_byte, dtype_str
+
+    def __eq__(self, other):
+        return self._spec_params == other._spec_params
+
+    def __hash__(self):
+        return hash(self._spec_params)
+
+    def set_default_byteorder(self, byteorder):
+        """ Set byteorder to use as default (if not specified by dtype). """
+        dtype = self.dtype.str
+        if not self.has_explicit_byteorder:
+            dtype = dtype[1:]
+        return type(self)(name=self.name, start_byte=self.start_byte, dtype=dtype, byteorder=byteorder)
+
+    def __repr__(self):
+        class_name = type(self).__name__
+        return f"{class_name}(name='{self.name}', start_byte={self.start_byte}, dtype='{self._spec_params[2]}')"
+
+    def to_tuple(self):
+        return self._spec_params
+
+    def to_dict(self):
+        return dict(zip(['name', 'start_byte', 'dtype'], self._spec_params))

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -140,6 +140,9 @@ class TraceHeaderSpec:
             dtype = dtype[1:]
         return type(self)(name=self.name, start_byte=self.start_byte, dtype=dtype, byteorder=byteorder)
 
+    def __repr__(self):
+        return f"{type(self).__name__}(name='{self.name}', start_byte={self.start_byte}, dtype='{self.dtype.str}')"
+
 
 class ForPoolExecutor(Executor):
     """ A sequential executor of tasks in a for loop.

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -48,7 +48,7 @@ class TraceHeaderSpec:
     start_byte : int, optional
         Byte position of the header, by default None. If None, default byte position from the spec will be used.
     dtype : int, str or dtype, optional
-        dtype for header (e.g. 'i2', '>f4') or its length in bytes (then is interpreted as integer type).
+        dtype for header (e.g. 'i2', '>f4', `np.float32`) or its length in bytes (then is interpreted as integer type).
     byteorder : '>' or '<', optional
         Endianness to use, if it's not defined by dtype. If None and dtype doesn't specify, architecture default
         will be used.
@@ -102,6 +102,7 @@ class TraceHeaderSpec:
         return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
 
     def set_default_byteorder(self, byteorder):
+        """ Set byteorder to use as default (if not specified by dtype). """
         return type(self)(name=self.name, start_byte=self.start_byte, dtype=self.dtype, byteorder=byteorder)
 
 

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -71,6 +71,7 @@ class TraceHeaderSpec:
             dtype = 'i' + str(dtype)
 
         self.dtype = np.dtype(dtype)
+        self.default_byteorder = byteorder
         self.has_explicit_byteorder = isinstance(dtype, str) and dtype[0] in {'>', '<'}
         if not self.has_explicit_byteorder and byteorder is not None:
             self.dtype = self.dtype.newbyteorder(byteorder)

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -76,10 +76,7 @@ class TraceHeaderSpec:
 
     @property
     def is_standard(self):
-        return self.name in segyio.tracefield.keys and \
-               self.start_byte == segyio.tracefield.keys[self.name] and \
-               self.byte_len == self.STANDARD_START_BYTE_TO_LEN[self.start_byte] and \
-               np.issubdtype(self.dtype, np.integer)
+        return self.name in self.STANDARD_BYTE_TO_HEADER and self.is_standard_except_name
 
     @property
     def is_standard_except_name(self):

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -76,7 +76,7 @@ class TraceHeaderSpec:
         if not self.has_explicit_byteorder and byteorder is not None:
             self.dtype = self.dtype.newbyteorder(byteorder)
 
-        if self.start_byte + self.byte_len > self.TRACE_HEADER_SIZE:
+        if self.start_byte + self.byte_len > self.TRACE_HEADER_SIZE + 1:
             raise ValueError(f'{self.name} header position is out of bounds')
 
     @property

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -83,7 +83,7 @@ class TraceHeaderSpec:
 
     @property
     def is_standard_except_name(self):
-        return self.start_byte == segyio.tracefield.keys[self.standard_name] and \
+        return self.start_byte in self.STANDARD_BYTE_TO_HEADER and \
                self.byte_len == self.STANDARD_START_BYTE_TO_LEN[self.start_byte] and \
                np.issubdtype(self.dtype, np.integer)
 

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -102,6 +102,33 @@ class TraceHeaderSpec:
             raise ValueError("The header has non-standard start byte or dtype")
         return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
 
+    @property
+    def has_default_byteorder(self):
+        return self.default_byteorder is not None
+
+    @property
+    def has_byteorder(self):
+        return self.has_explicit_byteorder or self.has_default_byteorder
+
+    @property
+    def byteorder(self):
+        if not self.has_byteorder:
+            return None
+        return self.dtype.str[0]
+
+    @property
+    def _spec_params(self):
+        dtype_str = self.dtype.str
+        if not self.has_byteorder:
+            dtype_str = dtype_str[1:]
+        return self.name, self.start_byte, dtype_str
+    
+    def __eq__(self, other):
+        return self._spec_params == other._spec_params
+    
+    def __hash__(self):
+        return hash(self._spec_params)
+
     def set_default_byteorder(self, byteorder):
         """ Set byteorder to use as default (if not specified by dtype). """
         dtype = self.dtype.str

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -104,7 +104,10 @@ class TraceHeaderSpec:
 
     def set_default_byteorder(self, byteorder):
         """ Set byteorder to use as default (if not specified by dtype). """
-        return type(self)(name=self.name, start_byte=self.start_byte, dtype=self.dtype, byteorder=byteorder)
+        dtype = self.dtype.str
+        if not self.has_explicit_byteorder:
+            dtype = dtype[1:]
+        return type(self)(name=self.name, start_byte=self.start_byte, dtype=dtype, byteorder=byteorder)
 
 
 class ForPoolExecutor(Executor):

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -71,7 +71,8 @@ class TraceHeaderSpec:
             dtype = 'i' + str(dtype)
 
         self.dtype = np.dtype(dtype)
-        if isinstance(dtype, str) and dtype[0] not in {'>', '<'} and byteorder is not None:
+        self.has_explicit_byteorder = isinstance(dtype, str) and dtype[0] in {'>', '<'}
+        if not self.has_explicit_byteorder and byteorder is not None:
             self.dtype = self.dtype.newbyteorder(byteorder)
 
         if self.start_byte + self.byte_len > self.TRACE_HEADER_SIZE:

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -60,14 +60,13 @@ class TraceHeaderSpec:
     def __init__(self, name=None, start_byte=None, dtype=None, byteorder=None):
         self.name = name or self.STANDARD_BYTE_TO_HEADER[start_byte]
         self.start_byte = start_byte or segyio.tracefield.keys[name]
-        # self.standard_name = self.STANDARD_BYTE_TO_HEADER.get(self.start_byte)
 
         dtype = dtype or self.STANDARD_START_BYTE_TO_LEN[self.start_byte]
         if isinstance(dtype, int):
             dtype = 'i' + str(dtype)
 
         self.dtype = np.dtype(dtype)
-        if self.dtype.byteorder not in {'>', '<'} and byteorder is not None:
+        if dtype[0] not in {'>', '<'} and byteorder is not None:
             self.dtype = self.dtype.newbyteorder(byteorder)
 
         self.byte_len = self.dtype.itemsize
@@ -92,7 +91,7 @@ class TraceHeaderSpec:
     def standard_name(self):
         return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
 
-    def set_byteorder(self, byteorder):
+    def set_default_byteorder(self, byteorder):
         return type(self)(name=self.name, start_byte=self.start_byte, dtype=self.dtype, byteorder=byteorder)
 
 

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -66,7 +66,7 @@ class TraceHeaderSpec:
             dtype = 'i' + str(dtype)
 
         self.dtype = np.dtype(dtype)
-        if dtype[0] not in {'>', '<'} and byteorder is not None:
+        if isinstance(dtype, str) and dtype[0] not in {'>', '<'} and byteorder is not None:
             self.dtype = self.dtype.newbyteorder(byteorder)
 
         self.byte_len = self.dtype.itemsize

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -68,10 +68,7 @@ class TraceHeader:
         if isinstance(other, str):
             return self.name == other
 
-        for attr in self.__dict__:
-            if getattr(self, attr) != getattr(other, attr):
-                return False
-        return True
+        return self.__dict__ == other.__dict__
 
 
 

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -105,14 +105,17 @@ class TraceHeaderSpec:
 
     @property
     def has_default_byteorder(self):
+        """ Whether default byteorder is defined. """
         return self.default_byteorder is not None
 
     @property
     def has_byteorder(self):
+        """ Whether byteorder is defined. """
         return self.has_explicit_byteorder or self.has_default_byteorder
 
     @property
     def byteorder(self):
+        """ Header byteorder (if defined). """
         if not self.has_byteorder:
             return None
         return self.dtype.str[0]
@@ -123,10 +126,10 @@ class TraceHeaderSpec:
         if not self.has_byteorder:
             dtype_str = dtype_str[1:]
         return self.name, self.start_byte, dtype_str
-    
+
     def __eq__(self, other):
         return self._spec_params == other._spec_params
-    
+
     def __hash__(self):
         return hash(self._spec_params)
 

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -57,13 +57,8 @@ class TraceHeaderSpec:
     STANDARD_START_BYTE_TO_LEN = {start: end - start
                             for start, end in zip(START_BYTES, START_BYTES[1:] + [TRACE_HEADER_SIZE + 1])}
 
-    def __init__(self, name, start_byte=None, dtype=None, byteorder=None):
-        if isinstance(name, int):
-            if start_byte is not None:
-                raise ValueError("'name' is int and 'byte' is defined")
-            name = self.STANDARD_BYTE_TO_HEADER[name]
-
-        self.name = name
+    def __init__(self, name=None, start_byte=None, dtype=None, byteorder=None):
+        self.name = name or self.STANDARD_BYTE_TO_HEADER[start_byte]
         self.start_byte = start_byte or segyio.tracefield.keys[name]
         # self.standard_name = self.STANDARD_BYTE_TO_HEADER.get(self.start_byte)
 
@@ -86,6 +81,16 @@ class TraceHeaderSpec:
                self.start_byte == segyio.tracefield.keys[self.name] and \
                self.byte_len == self.STANDARD_START_BYTE_TO_LEN[self.start_byte] and \
                np.issubdtype(self.dtype, np.integer)
+
+    @property
+    def is_standard_except_name(self):
+        return self.start_byte == segyio.tracefield.keys[self.standard_name] and \
+               self.byte_len == self.STANDARD_START_BYTE_TO_LEN[self.start_byte] and \
+               np.issubdtype(self.dtype, np.integer)
+
+    @property
+    def standard_name(self):
+        return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
 
     def set_byteorder(self, byteorder):
         return type(self)(name=self.name, start_byte=self.start_byte, dtype=self.dtype, byteorder=byteorder)

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -1,8 +1,6 @@
 """ !!. """
 from functools import partial
 from concurrent.futures import Future, Executor
-import numpy as np
-import segyio
 
 
 try:
@@ -35,113 +33,6 @@ except ImportError:
                 """ Do nothing on update. """
                 _ = n
 notifier = Notifier
-
-
-class TraceHeaderSpec:
-    """ Trace header class to store its name and byte position. By default, byte position is defined by name
-    accordingly to SEG-Y specification.
-
-    Parameters
-    ----------
-    name : str
-        Name of the header.
-    start_byte : int, optional
-        Byte position of the header, by default None. If None, default byte position from the spec will be used.
-    dtype : int, str or dtype, optional
-        dtype for header (e.g. 'i2', '>f4', `np.float32`) or its length in bytes (then is interpreted as integer type).
-    byteorder : '>' or '<', optional
-        Endianness to use, if it's not defined by dtype. If None and dtype doesn't specify, architecture default
-        will be used.
-    """
-    TRACE_HEADER_SIZE = 240
-
-    STANDARD_HEADER_TO_BYTE = segyio.tracefield.keys
-    STANDARD_BYTE_TO_HEADER = {v: k for k, v in STANDARD_HEADER_TO_BYTE.items()}
-
-    START_BYTES = sorted(STANDARD_HEADER_TO_BYTE.values())
-    STANDARD_BYTE_TO_LEN = {start: end - start
-                            for start, end in zip(START_BYTES, START_BYTES[1:] + [TRACE_HEADER_SIZE + 1])}
-
-    def __init__(self, name=None, start_byte=None, dtype=None, byteorder=None):
-        self.name = name or self.STANDARD_BYTE_TO_HEADER[start_byte]
-        self.start_byte = start_byte or self.STANDARD_HEADER_TO_BYTE[name]
-
-        dtype = dtype or self.STANDARD_BYTE_TO_LEN[self.start_byte]
-        if isinstance(dtype, int):
-            dtype = 'i' + str(dtype)
-
-        self.dtype = np.dtype(dtype)
-        self.default_byteorder = byteorder
-        self.has_explicit_byteorder = isinstance(dtype, str) and dtype[0] in {'>', '<'}
-        if not self.has_explicit_byteorder and byteorder is not None:
-            self.dtype = self.dtype.newbyteorder(byteorder)
-
-        if self.start_byte + self.byte_len > self.TRACE_HEADER_SIZE + 1:
-            raise ValueError(f'{self.name} header position is out of bounds')
-
-    @property
-    def byte_len(self):
-        """ The number of bytes for a header. """
-        return self.dtype.itemsize
-
-    @property
-    def is_standard(self):
-        """ Whether the header matches the specification. """
-        return self.name in self.STANDARD_BYTE_TO_HEADER and self.has_standard_location
-
-    @property
-    def has_standard_location(self):
-        """ Whether the header matches the specification, except maybe the name. """
-        return self.start_byte in self.STANDARD_BYTE_TO_HEADER and \
-               self.byte_len == self.STANDARD_BYTE_TO_LEN[self.start_byte] and \
-               np.issubdtype(self.dtype, np.integer)
-
-    @property
-    def standard_name(self):
-        """ The name from specification for header (if 'has_standard_location' is True). """
-        if not self.has_standard_location:
-            raise ValueError("The header has non-standard start byte or dtype")
-        return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
-
-    @property
-    def has_default_byteorder(self):
-        """ Whether default byteorder is defined. """
-        return self.default_byteorder is not None
-
-    @property
-    def has_byteorder(self):
-        """ Whether byteorder is defined. """
-        return self.has_explicit_byteorder or self.has_default_byteorder
-
-    @property
-    def byteorder(self):
-        """ Header byteorder (if defined). """
-        if not self.has_byteorder:
-            return None
-        return self.dtype.str[0]
-
-    @property
-    def _spec_params(self):
-        dtype_str = self.dtype.str
-        if not self.has_byteorder:
-            dtype_str = dtype_str[1:]
-        return self.name, self.start_byte, dtype_str
-
-    def __eq__(self, other):
-        return self._spec_params == other._spec_params
-
-    def __hash__(self):
-        return hash(self._spec_params)
-
-    def set_default_byteorder(self, byteorder):
-        """ Set byteorder to use as default (if not specified by dtype). """
-        dtype = self.dtype.str
-        if not self.has_explicit_byteorder:
-            dtype = dtype[1:]
-        return type(self)(name=self.name, start_byte=self.start_byte, dtype=dtype, byteorder=byteorder)
-
-    def __repr__(self):
-        return f"{type(self).__name__}(name='{self.name}', start_byte={self.start_byte}, dtype='{self.dtype.str}')"
 
 
 class ForPoolExecutor(Executor):

--- a/segfast/utils.py
+++ b/segfast/utils.py
@@ -86,6 +86,8 @@ class TraceHeaderSpec:
 
     @property
     def standard_name(self):
+        if not self.is_standard_except_name:
+            raise ValueError("The header has non-standard start byte or dtype")
         return self.STANDARD_BYTE_TO_HEADER[self.start_byte]
 
     def set_default_byteorder(self, byteorder):


### PR DESCRIPTION
* Now `load_headers` loads non-standard header by its start byte position and dtype.
* dtype can be float (e.g. `'>f4'`)
* Add `TraceHeaderSpec` class

Example:
```
file.load_headers(['INLINE_3D', ('CROSSLINE_3D', 17), {'name': 'another_strange_header', 'start_byte': 69, 'dtype': '>f4'}])
```