### PR TITLE
Allow loading trace headers for a subset of traces

### DIFF
--- a/segfast/memmap_loader.py
+++ b/segfast/memmap_loader.py
@@ -89,8 +89,8 @@ class MemmapLoader(SegyioLoader):
 
 
     # Headers loading
-    def load_headers(self, headers, indices=None, chunk_size=25_000, max_workers=4, pbar=False,
-                     reconstruct_tsf=True, sort_columns=True, **kwargs):
+    def load_headers(self, headers, indices=None, reconstruct_tsf=True, sort_columns=True, chunk_size=25_000,
+                     max_workers=4, pbar=False, **kwargs):
         """ Load requested trace headers from a SEG-Y file for each trace into a dataframe.
         If needed, we reconstruct the `'TRACE_SEQUENCE_FILE'` manually be re-indexing traces.
 
@@ -111,6 +111,10 @@ class MemmapLoader(SegyioLoader):
                 - dict -- kwargs to init :class:~`.utils.TraceHeaderSpec`.
         indices : sequence or None
             Indices of traces to load trace headers for. If not given, trace headers are loaded for all traces.
+        reconstruct_tsf : bool
+            Whether to reconstruct `TRACE_SEQUENCE_FILE` manually.
+        sort_columns : bool
+            Whether to sort columns in the resulting dataframe by their starting bytes.
         chunk_size : int
             Maximum amount of traces in each chunk.
         max_workers : int or None
@@ -118,8 +122,6 @@ class MemmapLoader(SegyioLoader):
         pbar : bool, str
             If bool, then whether to display progress bar over the file sweep.
             If str, then type of progress bar to display: `'t'` for textual, `'n'` for widget.
-        reconstruct_tsf : bool
-            Whether to reconstruct `TRACE_SEQUENCE_FILE` manually.
 
         Examples
         --------

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -94,7 +94,6 @@ class SegyioLoader:
         """ Optionally add TSF header and sort columns of a headers dataframe. """
         if reconstruct_tsf:
             dataframe['TRACE_SEQUENCE_FILE'] = self.make_tsf_header()
-            headers.append(TraceHeaderSpec('TRACE_SEQUENCE_FILE'))
 
         if sort_columns:
             headers_bytes = [item.start_byte for item in headers]

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -174,10 +174,12 @@ class SegyioLoader:
                 headers_.append(TraceHeaderSpec(**init_kwargs))
         return headers_
 
-    def load_header(self, header):
+    def load_header(self, header, indices=None):
         """ Read one header from the file. """
         header = self.make_headers_specs([header])[0]
-        return self.file_handler.attributes(header.start_byte)[:]
+        if indices is None:
+            indices = slice(None)
+        return self.file_handler.attributes(header.start_byte)[indices]
 
     def make_tsf_header(self):
         """ Reconstruct the `TRACE_SEQUENCE_FILE` header. """

--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -345,10 +345,6 @@ class SegyioLoader:
                                         strict=self.strict, ignore_geometry=self.ignore_geometry)
         self.file_handler.mmap()
 
-    def __del__(self):
-        """ Close SEG-Y file handler on loader destruction. """
-        self.file_handler.close()
-
 
 class SafeSegyioLoader(SegyioLoader):
     """ A thin wrapper around `segyio` library for convenient loading of headers and traces.


### PR DESCRIPTION
Now `load_header(s)` methods of both `SegyioLoader` and `MemmapLoader` allow passing `indices` of traces to load trace headers for. This may be useful to validate whether header specs were properly selected. By default all trace headers are loaded as before. The argument name is unified with that of `load_traces`.

Minor fixes:
* Now `load_header` logic is unified for both loaders,
* Now `load_header(s)` methods may return header specs used if `return_specs` flag is set to `True`.