### PR TITLE
Fix load_headers for indices as array

### DIFF
--- a/segfast/segyio_loader.py
+++ b/segfast/segyio_loader.py
@@ -189,7 +189,7 @@ class SegyioLoader:
         byteorder = self.ENDIANNESS_TO_SYMBOL[self.endian]
 
         if headers == 'all':
-            return [TraceHeaderSpec(start_byte, byteorder=byteorder)
+            return [TraceHeaderSpec(start_byte=start_byte, byteorder=byteorder)
                     for start_byte in TraceHeaderSpec.STANDARD_BYTE_TO_HEADER]
 
         headers_ = []


### PR DESCRIPTION
`np.array_split` doesn't split array into chunks of the same size (except last chunk). It tries to make all chunks of approximately the same size.